### PR TITLE
Add MathJax to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,20 @@ markdown_extensions:
         anchor_linenums: true
         line_spans: __span
         pygments_lang_class: true
+    - pymdownx.arithmatex:
+        generic: true
+
+extra_javascript:
+# Would be nice to use KaTeX, but something isn't working right in local testing
+    # - javascripts/katex.js
+    # - https://unpkg.com/katex@0/dist/katex.min.js
+    # - https://unpkg.com/katex@0/dist/contrib/auto-render.min.js
+    - javascripts/mathjax.js
+    - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
+# Also for KaTeX
+# extra_css:
+#   - https://unpkg.com/katex@0/dist/katex.min.css
 
 nav:
     # List of web pages to show, in order


### PR DESCRIPTION
I might have liked to use KaTeX instead of MathJax but couldn't get that to work on my machine, Material for MkDocs works a little more simply with MathJax.