### PR TITLE
Apply bracket unit style to comments and docstrings

### DIFF
--- a/lyopronto/calc_knownRp.py
+++ b/lyopronto/calc_knownRp.py
@@ -49,7 +49,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt):
     ##################  Initialization ################
 
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     # Time-dependent functions for Pchamber and Tshelf, take time in hours
     Pch_t = functions.RampInterpolator(Pchamber)
@@ -58,7 +58,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt):
     # Get maximum simulation time based on shelf and chamber setpoints
     # This may not really be necessary, but is part of legacy behavior
     # Could remove in a future release
-    max_t = max(Pch_t.max_time(), Tsh_t.max_time())   # hr, add buffer
+    max_t = max(Pch_t.max_time(), Tsh_t.max_time())   # [hr], add buffer
 
     if Pch_t.max_setpt() > functions.Vapor_pressure(Tsh_t.max_setpt()):
         warn("Chamber pressure setpoint exceeds vapor pressure at shelf temperature " +\
@@ -75,13 +75,13 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt):
     # taking them as arguments.
     def calc_dLdt(t, u):
         # Time in hours
-        Lck = u[0] # cm
+        Lck = u[0] # [cm]
         Tsh = Tsh_t(t)
         Pch = Pch_t(t)
-        Kv = functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch)  # Vial heat transfer coefficient in cal/s/K/cm^2
-        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
-        Tsub = fsolve(functions.T_sub_solver_FUN, T0, args = (Pch,vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Rp,Tsh))[0] # Sublimation front temperature array in degC
-        dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate array in kg/hr
+        Kv = functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch)  # Vial heat transfer coefficient [cal/s/K/cm^2]
+        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
+        Tsub = fsolve(functions.T_sub_solver_FUN, T0, args = (Pch,vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Rp,Tsh))[0] # Sublimation front temperature [degC]
+        dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate [kg/hr]
         if dmdt<0:
             # print("Shelf temperature is too low for sublimation.")
             dmdt = 0.0
@@ -89,7 +89,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt):
             return [dLdt]
         # Tbot = functions.T_bot_FUN(Tsub,Lpr0,Lck,Pch,Rp)    # Vial bottom temperature array in degC
 
-        dLdt = (dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm/hr
+        dLdt = (dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm/hr]
         return [dLdt]
 
     ### ------ Condition for ending simulation: completed drying

--- a/lyopronto/calc_unknownRp.py
+++ b/lyopronto/calc_unknownRp.py
@@ -27,14 +27,14 @@ def dry(vial,product,ht,Pchamber,Tshelf,time,Tbot_exp):
     ##################  Initialization ################
 
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     # Initialization of cake length
-    Lck = 0.0    # Cake length in cm
+    Lck = 0.0    # Cake length [cm]
     percent_dried = Lck/Lpr0*100.0        # Percent dried
 
     # Initial shelf temperature
-    Tsh = Tshelf['init']        # degC
+    Tsh = Tshelf['init']        # [degC]
     Tshelf = Tshelf.copy() # Don't edit the original argument!!
     Tshelf['setpt'] = np.insert(Tshelf['setpt'],0,Tshelf['init'])        # Include initial shelf temperature in set point array
     # Shelf temperature control time
@@ -43,7 +43,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,time,Tbot_exp):
         Tshelf['t_setpt'] = np.append(Tshelf['t_setpt'],Tshelf['t_setpt'][-1]+dt_i/constant.hr_To_min)
 
     # Initial chamber pressure
-    Pch = Pchamber['setpt'][0]        # Torr
+    Pch = Pchamber['setpt'][0]        # [Torr]
     Pchamber = Pchamber.copy() # Don't edit the original argument!!
     Pchamber['setpt'] = np.insert(Pchamber['setpt'],0,Pchamber['setpt'][0])        # Include initial chamber pressure in set point array
     # Chamber pressure control time
@@ -60,20 +60,20 @@ def dry(vial,product,ht,Pchamber,Tshelf,time,Tbot_exp):
 
     for iStep,t in enumerate(time): # Loop through for the time specified in the input file
 
-        Kv = functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch)  # Vial heat transfer coefficient in cal/s/K/cm^2
+        Kv = functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch)  # Vial heat transfer coefficient [cal/s/K/cm^2]
 
-        Tsub = sp.fsolve(functions.T_sub_Rp_finder, Tbot_exp[iStep], args = (vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Tbot_exp[iStep],Tsh))[0] # Sublimation front temperature array in degC
+        Tsub = sp.fsolve(functions.T_sub_Rp_finder, Tbot_exp[iStep], args = (vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Tbot_exp[iStep],Tsh))[0] # Sublimation front temperature [degC]
         # Q = Kv*vial['Av']*(Tsh - Tbot_exp[iStep])
         # Tsub = Tbot_exp[iStep] - Q/vial['Ap']/constant.k_ice*(Lpr0-Lck)
-        Rp = functions.Rp_finder(Tsub,Lpr0,Lck,Pch,Tbot_exp[iStep])    #     Product resistance in cm^2-Torr-hr/g
-        dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate array in kg/hr
+        Rp = functions.Rp_finder(Tsub,Lpr0,Lck,Pch,Tbot_exp[iStep])    # Product resistance [cm^2-Torr-hr/g]
+        dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate [kg/hr]
         if dmdt<0:
             warn(f"No sublimation. t={t:1.2f}, Tsh={Tsh:2.1f}, Tsub={Tsub:3.1f}, dmdt={dmdt:1.2e}, Rp={Rp:1.2f}, Lck={Lck:1.2f}")
             dmdt = 0.0
             Rp = 0.0
 
         # Sublimated ice length
-        dL = (dmdt*constant.kg_To_g)*dt[iStep]/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm
+        dL = (dmdt*constant.kg_To_g)*dt[iStep]/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm]
 
         # Update record as functions of the cycle time
         if (iStep==0):
@@ -84,7 +84,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,time,Tbot_exp):
             product_res = np.append(product_res, [[t, float(Lck), float(Rp)]],axis=0)
     
         # Advance counters
-        Lck = Lck + dL # Cake length in cm
+        Lck = Lck + dL # Cake length [cm]
 
         percent_dried = Lck/Lpr0*100   # Percent dried
 

--- a/lyopronto/constant.py
+++ b/lyopronto/constant.py
@@ -25,15 +25,15 @@ min_To_s = 60.0
 Torr_to_mTorr = 1000.0
 cal_To_J = 4.184
 
-rho_ice = 0.918 # g/mL
-rho_solute = 1.5 # g/mL
-rho_solution = 1.0  # g/mL
+rho_ice = 0.918 # [g/mL]
+rho_solute = 1.5 # [g/mL]
+rho_solution = 1.0  # [g/mL]
 
-dHs = 678.0 # Heat of sublimation in cal/g
-k_ice = 0.0059 # Thermal conductivity of ice in cal/cm/s/K
-dHf = 79.7 # Heat of fusion in cal/g
+dHs = 678.0 # Heat of sublimation [cal/g]
+k_ice = 0.0059 # Thermal conductivity of ice [cal/cm/s/K]
+dHf = 79.7 # Heat of fusion [cal/g]
 
-Cp_ice = 2030.0 # Constant pressure specific heat of ice in J/kg/K
-Cp_solution = 4000.0 # Constant pressure specific heat of water in J/kg/K
+Cp_ice = 2030.0 # Constant pressure specific heat of ice [J/kg/K]
+Cp_solution = 4000.0 # Constant pressure specific heat of water [J/kg/K]
 
 ##################################################

--- a/lyopronto/design_space.py
+++ b/lyopronto/design_space.py
@@ -42,11 +42,11 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
         ndarray: table of results for equipment capability curve
     
     The first two returns have 5 rows corresponding to:
-        - Maximum product temperature in degC
-        - Primary drying time in hr
-        - Average sublimation flux in kg/hr/m^2
-        - Maximum/minimum sublimation flux in kg/hr/m^2
-        - Sublimation flux at the end of primary drying in kg/hr/m^2
+        - Maximum product temperature [degC]
+        - Primary drying time [hr]
+        - Average sublimation flux [kg/hr/m^2]
+        - Maximum/minimum sublimation flux [kg/hr/m^2]
+        - Sublimation flux at the end of primary drying [kg/hr/m^2]
     The third return has 3 rows corresponding to the first three of that list.
 
     With nT setpoints in Tshelf['setpt'] and nP setpoints in Pchamber['setpt'], the returned arrays have the following shapes:
@@ -63,7 +63,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
     sub_flux_end = np.zeros([np.size(Tshelf['setpt']),np.size(Pchamber['setpt'])])
     
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     ############  Shelf temperature isotherms ##########
 
@@ -87,20 +87,20 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
             # Initialization of time
             iStep = 0      # Time iteration number
-            t = 0.0    # Time in hr
+            t = 0.0    # Time [hr]
 
             # Initialization of cake length
-            Lck = 0.0    # Cake length in cm
+            Lck = 0.0    # Cake length [cm]
 
             # Initial shelf temperature
-            Tsh = Tshelf['init']        # degC
-            # Time at which shelf temperature reaches set point in hr
+            Tsh = Tshelf['init']        # [degC]
+            # Time at which shelf temperature reaches set point [hr]
             t_setpt = abs(Tsh_setpt-Tshelf['init'])/Tshelf['ramp_rate']/constant.hr_To_min
        
             # Intial product temperature
-            T0=Tsh   # degC
+            T0=Tsh   # [degC]
 
-            # Vial heat transfer coefficient in cal/s/K/cm^2
+            # Vial heat transfer coefficient [cal/s/K/cm^2]
             Kv = functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch) 
 
             ######################################################
@@ -109,17 +109,17 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
             while(Lck<=Lpr0): # Dry the entire frozen product
     
-                Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
+                Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
 
-                Tsub = fsolve(functions.T_sub_solver_FUN, T0, args = (Pch,vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Rp,Tsh))[0] # Sublimation front temperature array in degC
-                dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate array in kg/hr
+                Tsub = fsolve(functions.T_sub_solver_FUN, T0, args = (Pch,vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Rp,Tsh))[0] # Sublimation front temperature [degC]
+                dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate [kg/hr]
                 if dmdt<0:
                     warn(f"At t={t}hr, shelf temperature Tsh={Tsh} is too low for sublimation.")
                     dmdt = 0.0
-                Tbot = functions.T_bot_FUN(Tsub,Lpr0,Lck,Pch,Rp)    # Vial bottom temperature array in degC
+                Tbot = functions.T_bot_FUN(Tsub,Lpr0,Lck,Pch,Rp)    # Vial bottom temperature [degC]
 
                 # Sublimated ice length
-                dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm
+                dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm]
             
             # Update record as functions of the cycle time
                 if (iStep==0):
@@ -128,14 +128,14 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
                     output_saved = np.append(output_saved, [[t, float(Tbot), dmdt/(vial['Ap']*constant.cm_To_m**2)]],axis=0)
     
                 # Advance counters
-                Lck_prev = Lck # Previous cake length in cm
-                Lck = Lck + dL # Cake length in cm
+                Lck_prev = Lck # Previous cake length [cm]
+                Lck = Lck + dL # Cake length [cm]
                 if (Lck_prev < Lpr0) and (Lck > Lpr0):
-                    Lck = Lpr0    # Final cake length in cm
-                    dL = Lck - Lck_prev   # Cake length dried in cm
-                    t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # hr
+                    Lck = Lpr0    # Final cake length [cm]
+                    dL = Lck - Lck_prev   # Cake length dried [cm]
+                    t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # [hr]
                 else:
-                    t = (iStep+1) * dt # Time in hr
+                    t = (iStep+1) * dt # Time [hr]
 
                 # Shelf temperature
                 if t<t_setpt:
@@ -150,8 +150,8 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
             ######################################################
 
-            T_max[i_Tsh,i_Pch] = np.max(output_saved[:,1])    # Maximum product temperature in C
-            drying_time[i_Tsh,i_Pch] = t    # Total drying time in hr
+            T_max[i_Tsh,i_Pch] = np.max(output_saved[:,1])    # Maximum product temperature [degC]
+            drying_time[i_Tsh,i_Pch] = t    # Total drying time [hr]
             # TODO: consider whether to make this error rather than return NaN
             if output_saved.shape[0] <= 2:
                 warn(f"At Tsh={Tsh} and Pch={Pch}, drying completed in single timestep: check inputs.")
@@ -161,9 +161,9 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
                 continue
             del_t = output_saved[1:,0]-output_saved[:-1,0]
             del_t = np.append(del_t,del_t[-1])
-            sub_flux_avg[i_Tsh,i_Pch] = np.sum(output_saved[:,2]*del_t)/np.sum(del_t)    # Average sublimation flux in kg/hr/m^2
-            sub_flux_max[i_Tsh,i_Pch] = np.max(output_saved[:,2])    # Maximum sublimation flux in kg/hr/m^2
-            sub_flux_end[i_Tsh,i_Pch] = output_saved[-1,2]    # Sublimation flux at the end of primary drying in kg/hr/m^2
+            sub_flux_avg[i_Tsh,i_Pch] = np.sum(output_saved[:,2]*del_t)/np.sum(del_t)    # Average sublimation flux [kg/hr/m^2]
+            sub_flux_max[i_Tsh,i_Pch] = np.max(output_saved[:,2])    # Maximum sublimation flux [kg/hr/m^2]
+            sub_flux_end[i_Tsh,i_Pch] = output_saved[-1,2]    # Sublimation flux at end of primary drying [kg/hr/m^2]
 
     ###########################################################################
 
@@ -180,12 +180,12 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
         # Initialization of time
         iStep = 0      # Time iteration number
-        t = 0.0    # Time in hr
+        t = 0.0    # Time [hr]
 
         # Initialization of cake length
-        Lck = 0.0    # Cake length in cm
+        Lck = 0.0    # Cake length [cm]
 
-        # Vial heat transfer coefficient in cal/s/K/cm^2
+        # Vial heat transfer coefficient [cal/s/K/cm^2]
         Kv = functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch) 
 
         ######################################################        
@@ -194,13 +194,13 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
         while(Lck<=Lpr0): # Dry the entire frozen product
     
-            Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
-    
-            Tsub = fsolve(functions.T_sub_fromTpr, product['T_pr_crit'], args = (product['T_pr_crit'],Lpr0,Lck,Pch,Rp))[0] # Sublimation front temperature array in degC
-            dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate array in kg/hr
-                
+            Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
+
+            Tsub = fsolve(functions.T_sub_fromTpr, product['T_pr_crit'], args = (product['T_pr_crit'],Lpr0,Lck,Pch,Rp))[0] # Sublimation front temperature [degC]
+            dmdt = functions.sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate [kg/hr]
+
             # Sublimated ice length
-            dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm
+            dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm]
 
             # Update record as functions of the cycle time
             if (iStep==0):
@@ -209,19 +209,19 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
                 output_saved = np.append(output_saved, [[t, dmdt/(vial['Ap']*constant.cm_To_m**2)]],axis=0)
         
             # Advance counters
-            Lck_prev = Lck # Previous cake length in cm
-            Lck = Lck + dL # Cake length in cm
+            Lck_prev = Lck # Previous cake length [cm]
+            Lck = Lck + dL # Cake length [cm]
             if (Lck_prev < Lpr0) and (Lck > Lpr0):
-                Lck = Lpr0    # Final cake length in cm
-                dL = Lck - Lck_prev   # Cake length dried in cm
-                t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # hr
+                Lck = Lpr0    # Final cake length [cm]
+                dL = Lck - Lck_prev   # Cake length dried [cm]
+                t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # [hr]
             else:
-                t = (iStep+1) * dt # Time in hr
+                t = (iStep+1) * dt # Time [hr]
             iStep = iStep + 1 # Time iteration number
 
         ######################################################
 
-        drying_time_pr[j] = t    # Total drying time in hr
+        drying_time_pr[j] = t    # Total drying time [hr]
         # TODO: consider whether this should error rather than return NaN
         if output_saved.shape[0] <= 2:
             warn(f"At Pch={Pch} and critical temp {product['T_pr_crit']}, drying completed in single timestep: check inputs.")
@@ -231,9 +231,9 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
             continue
         del_t = output_saved[1:,0]-output_saved[:-1,0]
         del_t = np.append(del_t,del_t[-1])
-        sub_flux_avg_pr[j] = np.sum(output_saved[:,1]*del_t)/np.sum(del_t)    # Average sublimation flux in kg/hr/m^2
-        sub_flux_min_pr[j] = np.min(output_saved[:,1])    # Minimum sublimation flux in kg/hr/m^2
-        sub_flux_end_pr[j] = output_saved[-1,1]    # Sublimation flux at the end of primary drying in kg/hr/m^2
+        sub_flux_avg_pr[j] = np.sum(output_saved[:,1]*del_t)/np.sum(del_t)    # Average sublimation flux [kg/hr/m^2]
+        sub_flux_min_pr[j] = np.min(output_saved[:,1])    # Minimum sublimation flux [kg/hr/m^2]
+        sub_flux_end_pr[j] = output_saved[-1,1]    # Sublimation flux at end of primary drying [kg/hr/m^2]
 
     ###########################################################################
 
@@ -241,19 +241,19 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
     ############  Equipment Capability ##########
 
-    dmdt_eq_cap = eq_cap['a'] + eq_cap['b']*np.array(Pchamber['setpt'])    # Sublimation rate in kg/hr
+    dmdt_eq_cap = eq_cap['a'] + eq_cap['b']*np.array(Pchamber['setpt'])    # Sublimation rate [kg/hr]
     if np.any(dmdt_eq_cap < 0):
         warn("Equipment capability sublimation rate is negative for some chamber pressures; setting to nan.")
         # dmdt_eq_cap = np.maximum(dmdt_eq_cap, 0.0)
         dmdt_eq_cap[dmdt_eq_cap <=0.0] = np.nan
-    sub_flux_eq_cap = dmdt_eq_cap/nVial/(vial['Ap']*constant.cm_To_m**2)    # Sublimation flux in kg/hr/m^2
-    
-    drying_time_eq_cap = Lpr0/((dmdt_eq_cap/nVial*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute))    # Drying time in hr
+    sub_flux_eq_cap = dmdt_eq_cap/nVial/(vial['Ap']*constant.cm_To_m**2)    # Sublimation flux [kg/hr/m^2]
 
-    Lck = np.linspace(0,Lpr0,100)    # Cake length in cm
-    Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])    # Product resistance in cm^2-hr-Torr/g
+    drying_time_eq_cap = Lpr0/((dmdt_eq_cap/nVial*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute))    # Drying time [hr]
+
+    Lck = np.linspace(0,Lpr0,100)    # Cake length [cm]
+    Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])    # Product resistance [cm^2-hr-Torr/g]
     for k,Pch in enumerate(Pchamber['setpt']):
-        T_max_eq_cap[k] = functions.Tbot_max_eq_cap(Pch,dmdt_eq_cap[k],Lpr0,Lck,Rp,vial['Ap'])        # Maximum product temperature in degC
+        T_max_eq_cap[k] = functions.Tbot_max_eq_cap(Pch,dmdt_eq_cap[k],Lpr0,Lck,Rp,vial['Ap'])        # Maximum product temperature [degC]
 
     #####################################################
 

--- a/lyopronto/freezing.py
+++ b/lyopronto/freezing.py
@@ -27,33 +27,33 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
     ##################  Initialization ################
 
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     # Frozen product volume
-    V_frozen = Lpr0*vial['Ap']    # mL
+    V_frozen = Lpr0*vial['Ap']    # [mL]
 
     # Initialization of time
     iStep = 0      # Time iteration number
-    t = 0.0    # Time in hr
+    t = 0.0    # Time [hr]
 
     # Initial shelf temperature
-    Tsh = Tshelf['init']        # degC
+    Tsh = Tshelf['init']        # [degC]
     
     # Shelf temperature and time triggers, ramping rates
     Tshr = RampInterpolator(Tshelf)
     Tsh_tr = Tshr.values
     t_tr = Tshr.times
-    r = np.array([[0.0]])    # degC/min
+    r = np.array([[0.0]])    # [degC/min]
     for i,T in enumerate(Tsh_tr[:-1]):
         if Tsh_tr[i+1]>T:
-            r = np.append(r,Tshelf['ramp_rate'])    # degC/min
+            r = np.append(r,Tshelf['ramp_rate'])    # [degC/min]
         elif Tsh_tr[i+1]<T:
-            r = np.append(r,-Tshelf['ramp_rate'])    # degC/min
+            r = np.append(r,-Tshelf['ramp_rate'])    # [degC/min]
         else:
-            r = np.append(r,0.0)    # degC/min
+            r = np.append(r,0.0)    # [degC/min]
 
     # Initial product temperature
-    Tpr = product['Tpr0']    # degC
+    Tpr = product['Tpr0']    # [degC]
     Tpr0 = Tpr
     i_prev = 1    
     
@@ -66,7 +66,7 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
     while(Tpr>product['Tn']): # Till the product reaches the nucleation temperature
 
         iStep = iStep + 1 # Time iteration number
-        t = iStep*dt # hr
+        t = iStep*dt # [hr]
 
         if np.all(t_tr<t):
             warn("Total time exceeded. Freezing incomplete, no nucleation occurred")    # Shelf temperature set point time exceeded, freezing not done
@@ -79,7 +79,7 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
             # Evaluate shelf temperature at current time point
             Tsh = Tshr(t)
             # Product temperature
-            Tpr = functions.lumped_cap_Tpr_sol(t-t_tr[i-1],Tpr0,vial['Vfill'],h_freezing,vial['Av'],Tsh,Tsh_tr[i-1],r[i])    # degC
+            Tpr = functions.lumped_cap_Tpr_sol(t-t_tr[i-1],Tpr0,vial['Vfill'],h_freezing,vial['Av'],Tsh,Tsh_tr[i-1],r[i])    # [degC]
 
         # Update record as functions of the cycle time
             freezing_output_saved = np.append(freezing_output_saved, [[t, Tsh, Tpr]],axis=0)    
@@ -94,9 +94,9 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
 
     ################ Crystallization ######################
 
-    tn = t    # Nucleation onset time in hr
-    dt_crystallization = functions.crystallization_time_FUN(vial['Vfill'],h_freezing,vial['Av'],product['Tf'],product['Tn'],Tshr, tn)    # Crystallization time in hr
-    ts = tn + dt_crystallization    # Solidification onset time in hr
+    tn = t    # Nucleation onset time [hr]
+    dt_crystallization = functions.crystallization_time_FUN(vial['Vfill'],h_freezing,vial['Av'],product['Tf'],product['Tn'],Tshr, tn)    # Crystallization time [hr]
+    ts = tn + dt_crystallization    # Solidification onset time [hr]
 
     while(t<ts):
 
@@ -108,22 +108,22 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
             if not(i == i_prev):
                 i_prev = i
             # Evaluate shelf temperature at current time point 
-            Tsh = Tshr(t)    # degC
+            Tsh = Tshr(t)    # [degC]
             # Product temperature stays at freezing temperature
-            Tpr = product['Tf']    # degC
+            Tpr = product['Tf']    # [degC]
 
         # Update record as functions of the cycle time
             freezing_output_saved = np.append(freezing_output_saved, [[t, Tsh, Tpr]],axis=0)
 
         iStep = iStep + 1 # Time iteration number
-        t = iStep*dt # hr    
+        t = iStep*dt # [hr]    
 
     ######################################################
 
     ################ Solidification ######################
 
     t_last = ts
-    Tpr0 = Tpr    # degC
+    Tpr0 = Tpr    # [degC]
     Tsh0 = Tsh
     while(t<t_tr[-1]):
 
@@ -135,7 +135,7 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
             Tsh0 = Tsh
 
         # Evaluate shelf temperature at current time point 
-        Tsh = Tshr(t)    # degC
+        Tsh = Tshr(t)    # [degC]
 
         # Product temperature
         Tpr = functions.lumped_cap_Tpr_ice(t-t_last,Tpr0,V_frozen,h_freezing,vial['Av'],Tsh,Tsh0,r[i])
@@ -143,7 +143,7 @@ def freeze(vial,product,h_freezing,Tshelf,dt):
         freezing_output_saved = np.append(freezing_output_saved, [[t, Tsh, Tpr]],axis=0)
 
         iStep = iStep + 1 # Time iteration number
-        t = iStep*dt # hr
+        t = iStep*dt # [hr]
 
     ######################################################
     

--- a/lyopronto/functions.py
+++ b/lyopronto/functions.py
@@ -28,74 +28,74 @@ from . import constant
 
 def Vapor_pressure(T_sub):
     """
-    Calculates the vapor pressure in Torr. Input is sublimation front
-    temperature in degC
+    Calculates the vapor pressure [Torr]. Input is sublimation front
+    temperature [degC]
     """
 
-    p = 2.698e10*np.exp(-6144.96/(273.15+T_sub))   # Vapor pressure at the sublimation temperature in Torr
+    p = 2.698e10*np.exp(-6144.96/(273.15+T_sub))   # Vapor pressure at the sublimation temperature [Torr]
 
     return p
 
 ##
 def Lpr0_FUN(Vfill,Ap,cSolid):
-    """Calculates the intial fill height of the frozen product in cm. 
+    """Calculates the intial fill height of the frozen product [cm].
 
     Args:
-        Vfill (float): fill volume in mL
-        Ap (float): product area in cm^2
-        cSolid (float): concentration of the solute in solution, g/mL
+        Vfill (float): fill volume [mL]
+        Ap (float): product area [cm^2]
+        cSolid (float): concentration of the solute in solution [g/mL]
 
     Returns:
-        (float): initial fill height of the frozen product, in cm.
+        (float): initial fill height of the frozen product [cm].
     """
 
     dens_fac = (constant.rho_solution-cSolid*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)
-    return Vfill/(Ap*constant.rho_ice)*dens_fac  # Fill height in cm
+    return Vfill/(Ap*constant.rho_ice)*dens_fac  # Fill height [cm]
 
 ##
 def Rp_FUN(L,R0,A1,A2):
-    """Calculates product resistance in cm^2-hr-Torr/g.
+    """Calculates product resistance [cm^2-hr-Torr/g].
 
     Args:
-        L (float): cake length in cm
-        R0 (float): base product resistance in cm^2-hr-Torr/g
-        A1 (float): product resistance parameter in cm-hr-Torr/g
-        A2 (float): product resistance parameter in 1/cm
-        
+        L (float): cake length [cm]
+        R0 (float): base product resistance [cm^2-hr-Torr/g]
+        A1 (float): product resistance parameter [cm-hr-Torr/g]
+        A2 (float): product resistance parameter [1/cm]
+
     Returns:
-        (float): product resistance in cm^2-hr-Torr/g
+        (float): product resistance [cm^2-hr-Torr/g]
     """
 
-    return R0 + A1*L/(1+A2*L) # Product resistance in cm^2-hr-Torr/g
+    return R0 + A1*L/(1+A2*L) # Product resistance [cm^2-hr-Torr/g]
 
 ##
 def Kv_FUN(KC,KP,KD,Pch):
     """Calculates the vial heat transfer coefficient.
 
     Args:
-        KC (float): Vial heat transfer parameter in cal/s/K/cm^2.
-        KP (float): Vial heat transfer parameter in cal/s/K/cm^2/Torr.
-        KD (float): Vial heat transfer parameter in 1/Torr.
-        Pch (float): Chamber pressure in Torr.
+        KC (float): Vial heat transfer parameter [cal/s/K/cm^2].
+        KP (float): Vial heat transfer parameter [cal/s/K/cm^2/Torr].
+        KD (float): Vial heat transfer parameter [1/Torr].
+        Pch (float): Chamber pressure [Torr].
 
     Returns:
-        (float): Vial heat transfer coefficient in cal/s/K/cm^2.
+        (float): Vial heat transfer coefficient [cal/s/K/cm^2].
     """
 
-    return KC + KP*Pch/(1.0+KD*Pch) # Kv in cal/s/K/cm^2
+    return KC + KP*Pch/(1.0+KD*Pch) # Kv [cal/s/K/cm^2]
 
 ##
 
 def T_sub_solver_FUN(T_sub_guess, *data):
     """Tsub is found from solving for T_unknown.
     Determines the function to calculate the sublimation temperature
-    represented as T_unknown. Other inputs are chamber pressure in Torr, vial
-    area in cm^2, product area in cm^2, vial heat transfer coefficient in
-    cal/s/K/cm^2, initial product length in cm, cake length in cm, product
-    resistance in cm^2-Torr-hr/g, and shelf temperature in degC
+    represented as T_unknown. Other inputs are chamber pressure [Torr], vial
+    area [cm^2], product area [cm^2], vial heat transfer coefficient
+    [cal/s/K/cm^2], initial product length [cm], cake length [cm], product
+    resistance [cm^2-Torr-hr/g], and shelf temperature [degC]
 
     Args:
-        T_sub_guess (float): Initial guess for the sublimation temperature in degC.
+        T_sub_guess (float): Initial guess for the sublimation temperature [degC].
         data (tuple): Pch, Av, Ap, Kv, Lpr0, Lck, Rp, Tsh
 
     Returns:
@@ -104,7 +104,7 @@ def T_sub_solver_FUN(T_sub_guess, *data):
     
     Pch, Av, Ap, Kv, Lpr0, Lck, Rp, Tsh = data
 
-    P_sub = Vapor_pressure(T_sub_guess)   # Vapor pressure at the sublimation temperature in Torr
+    P_sub = Vapor_pressure(T_sub_guess)   # Vapor pressure at the sublimation temperature [Torr]
     Qsub = constant.dHs*(P_sub-Pch)*Ap/Rp /constant.hr_To_s # Sublimation heat
     T_b = T_sub_guess + Qsub/Ap/constant.k_ice*(Lpr0-Lck) # Corresponding bottom temperature
     Qsh = Kv*Av*(Tsh - T_b) # Heat transfer from shelf
@@ -113,14 +113,14 @@ def T_sub_solver_FUN(T_sub_guess, *data):
 ##
 def sub_rate(Ap,Rp,T_sub,Pch):
     """
-    Calculates the sublimation rate from each vial in kg/hr. Inputs are
-    product area in cm^2, product resistance in cm^2-Torr-hr/g, sublimation
-    front temperature in degC, and chamber pressure in Torr
+    Calculates the sublimation rate from each vial [kg/hr]. Inputs are
+    product area [cm^2], product resistance [cm^2-Torr-hr/g], sublimation
+    front temperature [degC], and chamber pressure [Torr]
     """
 
-    P_sub = Vapor_pressure(T_sub)   # Vapor pressure at the sublimation temperature in Torr
+    P_sub = Vapor_pressure(T_sub)   # Vapor pressure at the sublimation temperature [Torr]
 
-    dm_dt = Ap/Rp/constant.kg_To_g*(P_sub-Pch)  # Sublimation rate in kg/hr
+    dm_dt = Ap/Rp/constant.kg_To_g*(P_sub-Pch)  # Sublimation rate [kg/hr]
 
     return dm_dt
 
@@ -128,29 +128,29 @@ def sub_rate(Ap,Rp,T_sub,Pch):
 ##
 def T_bot_FUN(T_sub,Lpr0,Lck,Pch,Rp):
     """
-    Calculates the temperature at the bottom of the vial in degC. Inputs are
-    sublimation front temperature in degC, initial product length in cm, cake
-    length in cm, chamber pressure in Torr, and product resistance in
-    cm^2-Torr-hr/g
+    Calculates the temperature at the bottom of the vial [degC]. Inputs are
+    sublimation front temperature [degC], initial product length [cm], cake
+    length [cm], chamber pressure [Torr], and product resistance
+    [cm^2-Torr-hr/g]
     """
 
-    P_sub = Vapor_pressure(T_sub)   # Vapor pressure at the sublimation temperature in Torr
+    P_sub = Vapor_pressure(T_sub)   # Vapor pressure at the sublimation temperature [Torr]
 
-    Tbot = T_sub + (Lpr0-Lck)*(P_sub-Pch)*constant.dHs/Rp/constant.hr_To_s/constant.k_ice # Vial bottom temperature in degC
+    Tbot = T_sub + (Lpr0-Lck)*(P_sub-Pch)*constant.dHs/Rp/constant.hr_To_s/constant.k_ice # Vial bottom temperature [degC]
 
     return Tbot
 	
 ##
 def Rp_finder(T_sub,Lpr0,Lck,Pch,Tbot):
     """
-    Calculates product resistance in cm^2-hr-Torr/g. Inputs are sublimation
-    temperature in degC, initial product length in cm, cake length in cm,
-    chamber pressure in Torr, and vial bottom temperature in degC
+    Calculates product resistance [cm^2-hr-Torr/g]. Inputs are sublimation
+    temperature [degC], initial product length [cm], cake length [cm],
+    chamber pressure [Torr], and vial bottom temperature [degC]
     """
 
-    P_sub = Vapor_pressure(T_sub)   # Vapor pressure at the sublimation temperature in Torr
+    P_sub = Vapor_pressure(T_sub)   # Vapor pressure at the sublimation temperature [Torr]
 
-    Rp = (Lpr0-Lck)*(P_sub-Pch)*constant.dHs/(Tbot-T_sub)/constant.hr_To_s/constant.k_ice	# Product resistance in cm^2-Torr-hr/g
+    Rp = (Lpr0-Lck)*(P_sub-Pch)*constant.dHs/(Tbot-T_sub)/constant.hr_To_s/constant.k_ice	# Product resistance [cm^2-Torr-hr/g]
 
     return Rp
 
@@ -160,10 +160,10 @@ def T_sub_Rp_finder(T_sub, *data):
     """
     Tsub is found from solving for T_unknown.
     Determines the function to calculate the sublimation temperature
-    represented as T_unknown. Other inputs are chamber pressure in Torr, vial
-    area in cm^2, product area in cm^2, vial heat transfer coefficient in
-    cal/s/K/cm^2, initial product length in cm, cake length in cm, vial bottom 
-    temperature in degC, and shelf temperature in degC
+    represented as T_unknown. Other inputs are chamber pressure [Torr], vial
+    area [cm^2], product area [cm^2], vial heat transfer coefficient
+    [cal/s/K/cm^2], initial product length [cm], cake length [cm], vial bottom
+    temperature [degC], and shelf temperature [degC]
     """
     
     Av, Ap, Kv, Lpr0, Lck, Tbot, Tsh = data
@@ -178,14 +178,14 @@ def T_sub_Rp_finder(T_sub, *data):
 def T_sub_fromTpr(T_unknown, *data):
     """
     Tsub is found from solving for T_unknown.  # Determines the function to calculate the sublimation temperature
-    represented as T_unknown. Other inputs are vial bottom temperature in degC, 
-    initial product length in cm, cake length in cm, chamber pressure in Torr,
-    and product resistance in cm^2-Torr-hr/g
+    represented as T_unknown. Other inputs are vial bottom temperature [degC],
+    initial product length [cm], cake length [cm], chamber pressure [Torr],
+    and product resistance [cm^2-Torr-hr/g]
     """
     
     Tbot, Lpr0, Lck, Pch, Rp = data
 
-    P_sub = Vapor_pressure(T_unknown)   # Vapor pressure at the sublimation temperature in Torr
+    P_sub = Vapor_pressure(T_unknown)   # Vapor pressure at the sublimation temperature [Torr]
 
     F = T_unknown - Tbot + (P_sub-Pch)*(Lpr0-Lck)*constant.dHs/Rp/constant.hr_To_s/constant.k_ice  # Heat and mass transfer energy balance function - Should be zero
 
@@ -195,25 +195,25 @@ def T_sub_fromTpr(T_unknown, *data):
 
 def Tbot_max_eq_cap(Pch,dm_dt,Lpr0,Lck,Rp,Ap):
     """
-    Calculates the maximum product temperature (occus at vial bottom) in
-    degC. Inputs are chamber pressure in Torr, sublimation rate based on
-    equipment capability in kg/hr, initial product length in cm, cake length
-    in cm, product resistance in cm^2-Torr-hr/g, and product area in cm^2
+    Calculates the maximum product temperature (occurs at vial bottom)
+    [degC]. Inputs are chamber pressure [Torr], sublimation rate based on
+    equipment capability [kg/hr], initial product length [cm], cake length
+    [cm], product resistance [cm^2-hr-Torr/g], and product area [cm^2]
     """
 
-    P_sub = dm_dt/Ap*Rp + Pch     # Sublimation front pressure in Torr
-    T_sub = -6144.96/np.log(P_sub/2.698e10) - 273.15    # Sublimation front temperature in degC
-    Tbot = T_sub + (Lpr0-Lck)*(P_sub-Pch)*constant.dHs/Rp/constant.hr_To_s/constant.k_ice	#Vial bottom temperature in degC
-    Tbot_max = np.max(Tbot)   # Maximum vial bottom temperature in degC
+    P_sub = dm_dt/Ap*Rp + Pch     # Sublimation front pressure [Torr]
+    T_sub = -6144.96/np.log(P_sub/2.698e10) - 273.15    # Sublimation front temperature [degC]
+    Tbot = T_sub + (Lpr0-Lck)*(P_sub-Pch)*constant.dHs/Rp/constant.hr_To_s/constant.k_ice	# Vial bottom temperature [degC]
+    Tbot_max = np.max(Tbot)   # Maximum vial bottom temperature [degC]
 
     return Tbot_max
 
 def Ineq_Constraints(Pch,dm_dt,Tcrit,Tbot,a,b,nVial):
     """
     Defines the inequality constraints for lyophilization optimization within
-    safe operation region inside the desgin space. Inputs are chamber pressure in Torr,
-    sublimation rate in kg/hr, critical product temperature in degC, vial bottom
-    temperature in degC, equipment capability parameters a in kg/hr and b in kg/hr/Torr,
+    safe operation region inside the desgin space. Inputs are chamber pressure [Torr],
+    sublimation rate [kg/hr], critical product temperature [degC], vial bottom
+    temperature [degC], equipment capability parameters a [kg/hr] and b [kg/hr/Torr],
     and number of vials
     """
 
@@ -227,20 +227,20 @@ def Ineq_Constraints(Pch,dm_dt,Tcrit,Tbot,a,b,nVial):
 
 def Eq_Constraints(Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv,Lpr0,Lck,Av,Ap,Rp):
     """
-    Defines the equality constraints for lyophilization. Inputs are chamber pressure in Torr,
-    sublimation rate in kg/hr, vial bottom temperature in degC, shelf temperature in degC,
-    sublimation front pressure in Torr, sublimation front temperature in degC, vial heat
-    transfer coefficient in cal/s/cm^2/C, initial product length in cm, cake length in cm,
-    vial area in cm^2, product area in cm^2, and product resistance in cm^2-Torr-hr/g 
+    Defines the equality constraints for lyophilization. Inputs are chamber pressure [Torr],
+    sublimation rate [kg/hr], vial bottom temperature [degC], shelf temperature [degC],
+    sublimation front pressure [Torr], sublimation front temperature [degC], vial heat
+    transfer coefficient [cal/s/cm^2/K], initial product length [cm], cake length [cm],
+    vial area [cm^2], product area [cm^2], and product resistance [cm^2-Torr-hr/g]
     """
 
-    C1 = Psub - 2.698e10*np.exp(-6144.96/(273.15+Tsub))   # Vapor pressure at the sublimation temperature in Torr
+    C1 = Psub - 2.698e10*np.exp(-6144.96/(273.15+Tsub))   # Vapor pressure at the sublimation temperature [Torr]
     
-    C2 = dmdt - Ap/Rp/constant.kg_To_g*(Psub-Pch)  # Sublimation rate in kg/hr
+    C2 = dmdt - Ap/Rp/constant.kg_To_g*(Psub-Pch)  # Sublimation rate [kg/hr]
     
     C3 = (Tsh-Tbot)*Av*Kv*(Lpr0-Lck) - Ap*(Tbot-Tsub)*constant.k_ice  # Vial heat transfer balance
 
-    C4 = Tsh - dmdt*constant.kg_To_g/constant.hr_To_s*constant.dHs/Av/Kv - Tbot  # Shelf temperature in C
+    C4 = Tsh - dmdt*constant.kg_To_g/constant.hr_To_s*constant.dHs/Av/Kv - Tbot  # Shelf temperature [degC]
 
     return C1,C2,C3,C4
 
@@ -248,17 +248,17 @@ def Eq_Constraints(Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv,Lpr0,Lck,Av,Ap,Rp):
 
 def lumped_cap_Tpr_abstract(t,Tpr0,V,h,Av,Tsh,Tsh0,Tsh_ramp,rho,Cpi):
     """
-    Calculates the product temperature in C. Inputs are time in hr, initial product temperature in degC, product density in g/mL, constant pressure specific heat of the product in J/kg/K, product volume in mL, heat transfer coefficient in W/m^2/K, vial area in cm^2, current shelf temperature in degC, initial shelf temperature in degC, shelf temperature ramping rate in degC/min
+    Calculates the product temperature [degC]. Inputs are time [hr], initial product temperature [degC], product density [g/mL], constant pressure specific heat of the product [J/kg/K], product volume [mL], heat transfer coefficient [W/m^2/K], vial area [cm^2], current shelf temperature [degC], initial shelf temperature [degC], shelf temperature ramping rate [degC/min]
     """
 
-    rr = Tsh_ramp/constant.min_To_s # K/s, ramp rate
-    rhoV = rho*V  # g, mass of solution
-    Cp = Cpi/constant.kg_To_g # J/g/K, specific heat capacity
-    hA = h*Av*constant.cm_To_m**2  # W/K, heat transfer coefficient times area
-    ts = t*constant.hr_To_s # s, time
+    rr = Tsh_ramp/constant.min_To_s # Ramp rate [K/s]
+    rhoV = rho*V  # Mass of solution [g]
+    Cp = Cpi/constant.kg_To_g # Specific heat capacity [J/g/K]
+    hA = h*Av*constant.cm_To_m**2  # Heat transfer coefficient times area [W/K]
+    ts = t*constant.hr_To_s # Time [s]
 
-    tau = rhoV*Cp/hA  # s, time constant
-    asymp_T = (Tpr0 - Tsh0 + rr*rhoV*Cp/hA) # degC, prefactor in solution
+    tau = rhoV*Cp/hA  # Time constant [s]
+    asymp_T = (Tpr0 - Tsh0 + rr*rhoV*Cp/hA) # Prefactor in solution [degC]
 
     return asymp_T*np.exp(-ts/tau) - rr*tau + Tsh
 
@@ -318,14 +318,14 @@ class RampInterpolator:
 
 def crystallization_time_FUN(V,h,Av,Tf,Tn,Tsh_func,t0):
     """
-    Calculates the crystallization time in hr. Inputs are fill volume in mL, heat transfer coefficient in W/m^2/K, vial area in cm^2, freezing temperature in degC, nucleation temperature in degC, shelf temperature in degC
+    Calculates the crystallization time [hr]. Inputs are fill volume [mL], heat transfer coefficient [W/m^2/K], vial area [cm^2], freezing temperature [degC], nucleation temperature [degC], shelf temperature [degC]
     """
 
     # t = constant.rho_solution*V*(constant.dHf*constant.cal_To_J-constant.Cp_solution/constant.kg_To_g*(Tf-Tn))/h/constant.hr_To_s/Av/constant.cm_To_m**2/(Tf-Tsh)
-    rhoV = constant.rho_solution*V  # mass of the solution in g
-    Hf = constant.dHf*constant.cal_To_J # fusion enthalpy in J/g
-    Cp = constant.Cp_solution/constant.kg_To_g # specific heat capacity in J/g/K
-    hA = h*constant.hr_To_s * Av*constant.cm_To_m**2 # heat transfer coefficient in J/K/hr
+    rhoV = constant.rho_solution*V  # Mass of the solution [g]
+    Hf = constant.dHf*constant.cal_To_J # Fusion enthalpy [J/g]
+    Cp = constant.Cp_solution/constant.kg_To_g # Specific heat capacity [J/g/K]
+    hA = h*constant.hr_To_s * Av*constant.cm_To_m**2 # Heat transfer coefficient [J/K/hr]
     # t = rhoV*(Hf-Cp*(Tf-Tn))/hA/(Tf-Tsh) # time: g*(J/g- J/g/K*K)/(J/m^2/K/hr*m^2*K) = hr
     lhs = rhoV*(Hf-Cp*(Tf-Tn))/hA
     def integrand(dt):
@@ -346,7 +346,7 @@ def calc_step(t, Lck, inputs):
 
     Args:
         t (float): The current time in hours.
-        Lck (float): The cake thickness in cm.
+        Lck (float): The cake thickness [cm].
         inputs (tuple): A tuple containing the inputs parameters.
 
     Returns:
@@ -362,16 +362,16 @@ def calc_step(t, Lck, inputs):
     vial, product, ht, Pch_t, Tsh_t, dt, Lpr0 = inputs
     Tsh = Tsh_t(t)
     Pch = Pch_t(t)
-    Kv = Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch)  # Vial heat transfer coefficient in cal/s/K/cm^2
-    Rp = Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
-    Tsub = fsolve(T_sub_solver_FUN, 250, args = (Pch,vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Rp,Tsh))[0] # Sublimation front temperature array in degC
-    dmdt = sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate array in kg/hr
+    Kv = Kv_FUN(ht['KC'],ht['KP'],ht['KD'],Pch)  # Vial heat transfer coefficient [cal/s/K/cm^2]
+    Rp = Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
+    Tsub = fsolve(T_sub_solver_FUN, 250, args = (Pch,vial['Av'],vial['Ap'],Kv,Lpr0,Lck,Rp,Tsh))[0] # Sublimation front temperature [degC]
+    dmdt = sub_rate(vial['Ap'],Rp,Tsub,Pch)   # Total sublimation rate [kg/hr]
     if dmdt<0:
         dmdt = 0.0
         Tsub = Tsh  # No sublimation, Tsub equals shelf temp
         Tbot = Tsh
     else:
-        Tbot = T_bot_FUN(Tsub,Lpr0,Lck,Pch,Rp)    # Vial bottom temperature array in degC
+        Tbot = T_bot_FUN(Tsub,Lpr0,Lck,Pch,Rp)    # Vial bottom temperature [degC]
     dry_percent = (Lck/Lpr0)*100
 
     col = np.array([t, Tsub, Tbot, Tsh, Pch*constant.Torr_to_mTorr, dmdt/(vial['Ap']*constant.cm_To_m**2), dry_percent])

--- a/lyopronto/high_level.py
+++ b/lyopronto/high_level.py
@@ -601,9 +601,9 @@ def _plot_design_space(data, inputs, props, timestamp):
     )
     # Design space: sublimation flux vs pressures
 
-    # Range in pressure space, min to max, Torr
+    # Range in pressure space, min to max [Torr]
     x = np.linspace(np.min(Pchamber), np.max(Pchamber), 1000)
-    # Line 1: equipment capability sub flux, kg/hr/m^2
+    # Line 1: equipment capability sub flux [kg/hr/m^2]
     # Indices (2,-1) is average sub flux at last Pch setpt,
     #         (2,0) is average sub flux at first Pch setpt
     # Slope: (delta sub flux)/(delta pressure)
@@ -611,7 +611,7 @@ def _plot_design_space(data, inputs, props, timestamp):
     y1 = ((ds_eq_cap[2, -1] - ds_eq_cap[2, 0]) / (Pchamber[-1] - Pchamber[0])) * (
         x - Pchamber[0]
     ) + ds_eq_cap[2, 0]
-    # Line 2: product temperature limited sub flux, kg/hr/m^2
+    # Line 2: product temperature limited sub flux [kg/hr/m^2]
     # Indices (3, -1) is minimum sub flux at last setpt,
     #          (3,0) is minimum sub flux at first setpt
     # Slope: (delta sub flux)/(delta pressure)
@@ -692,7 +692,7 @@ def _plot_design_space(data, inputs, props, timestamp):
     # Drying time vs pressures
 
     #### First, filled area above constraints
-    # Pressure range in Torr
+    # Pressure range [Torr]
     x = np.linspace(np.min(Pchamber), np.max(Pchamber), 1000)
     # Line 1: drying time limited by equipment capability
     y1 = np.interp(x, Pchamber, ds_eq_cap[1, :])
@@ -746,11 +746,11 @@ def _plot_design_space(data, inputs, props, timestamp):
 
     # Product temperature vs pressures
 
-    x = np.linspace(np.min(Pchamber), np.max(Pchamber), 1000)  # pressure range in Torr
+    x = np.linspace(np.min(Pchamber), np.max(Pchamber), 1000)  # Pressure range [Torr]
     # Curve 1: equipment capability limited product temperature
     y1 = np.interp(
         x, Pchamber, ds_eq_cap[0, :]
-    )  # equipment capability limiting product temperature in degC
+    )  # Equipment capability limiting product temperature [degC]
     # Curve 2: horizontal line at product temperature limit
     y2 = np.full_like(y1, T_pr_crit)  # horizontal line at product temperature limit
     y = np.minimum(y1, y2)

--- a/lyopronto/opt_Pch.py
+++ b/lyopronto/opt_Pch.py
@@ -30,21 +30,21 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
     ##################  Initialization ################
 
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     # Initialization of time
     iStep = 0      # Time iteration number
-    t = 0.0    # Time in hr
+    t = 0.0    # Time [hr]
 
     # Initialization of cake length
-    Lck = 0.0    # Cake length in cm
+    Lck = 0.0    # Cake length [cm]
     percent_dried = Lck/Lpr0*100.0        # Percent dried
 
     # Initial chamber pressure: middle of range, or 2*min if only min given
     P0 = (Pchamber['min'] + Pchamber.get('max', Pchamber['min']*3))/2.0    
 
     # Initial shelf temperature
-    Tsh = Tshelf['init']        # degC
+    Tsh = Tshelf['init']        # [degC]
     Tshelf = Tshelf.copy()
     Tshelf['setpt'] = np.insert(Tshelf['setpt'],0,Tshelf['init'])        # Include initial shelf temperature in set point array
     # Shelf temperature control time
@@ -53,9 +53,9 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
         Tshelf['t_setpt'] = np.append(Tshelf['t_setpt'],Tshelf['t_setpt'][-1]+dt_i/constant.hr_To_min)
        
     # Initial product and shelf temperatures
-    Tb0 = product['T_pr_crit'] -0.1   # degC
-    Ts0 = Tb0 - 0.1   # degC
-    Tsh0 = Tb0 +0.1   # degC
+    Tb0 = product['T_pr_crit'] -0.1   # [degC]
+    Ts0 = Tb0 - 0.1   # [degC]
+    Tsh0 = Tb0 +0.1   # [degC]
 
     ######################################################
 
@@ -69,22 +69,22 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
     while(Lck<=Lpr0): # Dry the entire frozen product
 
-        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
-    
+        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
+
         # Constraints
-        cons = ({'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[0]},  # sublimation front pressure in Torr
-            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[1]},    # sublimation rate in kg/hr
+        cons = ({'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[0]},  # sublimation front pressure [Torr]
+            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[1]},    # sublimation rate [kg/hr]
             {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[2]},    # vial heat transfer balance
-            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[3]},    # shelf temperature in degC
-            {'type':'eq','fun':lambda x: x[6]-functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],x[0])},    # vial heat transfer coefficient in cal/s/K/cm^2
-            {'type':'eq','fun':lambda x: x[3]-Tsh},    # shelf temperature fixed in degC
+            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[3]},    # shelf temperature [degC]
+            {'type':'eq','fun':lambda x: x[6]-functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],x[0])},    # vial heat transfer coefficient [cal/s/K/cm^2]
+            {'type':'eq','fun':lambda x: x[3]-Tsh},    # shelf temperature fixed [degC]
             {'type':'ineq','fun':lambda x: functions.Ineq_Constraints(x[0],x[1],product['T_pr_crit'],x[2],eq_cap['a'],eq_cap['b'],nVial)[0]},  # equipment capability inequlity
             {'type':'ineq','fun':lambda x: functions.Ineq_Constraints(x[0],x[1],product['T_pr_crit'],x[2],eq_cap['a'],eq_cap['b'],nVial)[1]})  # maximum product temperature inequality
         # Bounds for the unknowns
         bnds = ((Pchamber['min'],Pchamber.get('max', None)),(0,None),(None,None),(None,None),(0,None),(None,None),(0,None))
         # Minimize the objective function i.e. maximize the sublimation rate
         res = sp.minimize(objfun,x0,bounds = bnds, constraints = cons)
-        [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv] = res['x']    # Results in Torr, kg/hr, degC, degC, Torr, degC, cal/s/K/cm^2
+        [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv] = res['x']    # Results [Torr], [kg/hr], [degC], [degC], [Torr], [degC], [cal/s/K/cm^2]
         # # Use the results as a guess for the next iteration
         # TODO: decide on appropriate error handling for unsuccessful iterations
         # Should check some simple conditions probably and see if inputs have any feasible solutions
@@ -100,7 +100,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
                 continue
 
         # Sublimated ice length
-        dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm
+        dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm]
 
         # Update record as functions of the cycle time
         if (iStep==0):
@@ -109,14 +109,14 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
             output_saved = np.append(output_saved, [[t, float(Tsub), float(Tbot), Tsh, Pch*constant.Torr_to_mTorr, dmdt/(vial['Ap']*constant.cm_To_m**2), percent_dried]],axis=0)
     
         # Advance counters
-        Lck_prev = Lck # Previous cake length in cm
-        Lck = Lck + dL # Cake length in cm
+        Lck_prev = Lck # Previous cake length [cm]
+        Lck = Lck + dL # Cake length [cm]
         if (Lck_prev < Lpr0) and (Lck > Lpr0):
-            Lck = Lpr0    # Final cake length in cm
-            dL = Lck - Lck_prev   # Cake length dried in cm
-            t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # hr
+            Lck = Lpr0    # Final cake length [cm]
+            dL = Lck - Lck_prev   # Cake length dried [cm]
+            t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # [hr]
         else:
-            t = (iStep+1) * dt # Time in hr
+            t = (iStep+1) * dt # Time [hr]
 
         percent_dried = Lck/Lpr0*100   # Percent dried
 

--- a/lyopronto/opt_Pch_Tsh.py
+++ b/lyopronto/opt_Pch_Tsh.py
@@ -27,21 +27,21 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
     ##################  Initialization ################
 
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     # Initialization of time
     iStep = 0      # Time iteration number
-    t = 0.0    # Time in hr
+    t = 0.0    # Time [hr]
 
     # Initialization of cake length
-    Lck = 0.0    # Cake length in cm
+    Lck = 0.0    # Cake length [cm]
     percent_dried = Lck/Lpr0*100.0        # Percent dried
 
     # Initial chamber pressure
-    P0 = 0.1    # Initial guess for chamber pressure in Torr
+    P0 = 0.1    # Initial guess for chamber pressure [Torr]
        
     # Initial product and shelf temperatures
-    T0=product['T_pr_crit']   # degC
+    T0=product['T_pr_crit']   # [degC]
 
     ######################################################
 
@@ -49,28 +49,28 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
     while(Lck<=Lpr0): # Dry the entire frozen product
 
-        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
+        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
     
         # Quantities solved for: x = [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv]
         def fun(x): 
             return x[0]-x[4]    # Objective function to be minimized to maximize sublimation rate
         x0 = [P0,0.0,T0,T0,P0,T0,3.0e-4]    # Initial values
         # Constraints
-        cons = ({'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[0]},  # sublimation front pressure in Torr
-            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[1]},    # sublimation rate in kg/hr
+        cons = ({'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[0]},  # sublimation front pressure [Torr]
+            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[1]},    # sublimation rate [kg/hr]
             {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[2]},    # vial heat transfer balance
-            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[3]},    # shelf temperature in degC
-            {'type':'eq','fun':lambda x: x[6]-functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],x[0])},    # vial heat transfer coefficient in cal/s/K/cm^2
+            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[3]},    # shelf temperature [degC]
+            {'type':'eq','fun':lambda x: x[6]-functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],x[0])},    # vial heat transfer coefficient [cal/s/K/cm^2]
             {'type':'ineq','fun':lambda x: functions.Ineq_Constraints(x[0],x[1],product['T_pr_crit'],x[2],eq_cap['a'],eq_cap['b'],nVial)[0]},  # equipment capability inequlity
             {'type':'ineq','fun':lambda x: functions.Ineq_Constraints(x[0],x[1],product['T_pr_crit'],x[2],eq_cap['a'],eq_cap['b'],nVial)[1]})  # maximum product temperature inequality
         # Bounds for the unknowns
         bnds = ((Pchamber['min'],None),(None,None),(None,None),(Tshelf['min'],Tshelf['max']),(None,None),(None,None),(None,None))
         # Minimize the objective function i.e. maximize the sublimation rate
         res = sp.minimize(fun,x0,bounds = bnds, constraints = cons)
-        [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv] = res['x']    # Results in Torr, kg/hr, degC, degC, Torr, degC, cal/s/K/cm^2
+        [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv] = res['x']    # Results [Torr], [kg/hr], [degC], [degC], [Torr], [degC], [cal/s/K/cm^2]
 
         # Sublimated ice length
-        dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm
+        dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm]
 
         # Update record as functions of the cycle time
         if (iStep==0):
@@ -79,14 +79,14 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
             output_saved = np.append(output_saved, [[t, float(Tsub), float(Tbot), Tsh, Pch*constant.Torr_to_mTorr, dmdt/(vial['Ap']*constant.cm_To_m**2), percent_dried]],axis=0)
         
         # Advance counters
-        Lck_prev = Lck # Previous cake length in cm
-        Lck = Lck + dL # Cake length in cm
+        Lck_prev = Lck # Previous cake length [cm]
+        Lck = Lck + dL # Cake length [cm]
         if (Lck_prev < Lpr0) and (Lck > Lpr0):
-            Lck = Lpr0    # Final cake length in cm
-            dL = Lck - Lck_prev   # Cake length dried in cm
-            t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # hr
+            Lck = Lpr0    # Final cake length [cm]
+            dL = Lck - Lck_prev   # Cake length dried [cm]
+            t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # [hr]
         else:
-            t = (iStep+1) * dt # Time in hr
+            t = (iStep+1) * dt # Time [hr]
 
         percent_dried = Lck/Lpr0*100   # Percent dried
         

--- a/lyopronto/opt_Tsh.py
+++ b/lyopronto/opt_Tsh.py
@@ -28,18 +28,18 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
     ##################  Initialization ################
 
     # Initial fill height
-    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # cm
+    Lpr0 = functions.Lpr0_FUN(vial['Vfill'],vial['Ap'],product['cSolid'])   # [cm]
 
     # Initialization of time
     iStep = 0      # Time iteration number
-    t = 0.0    # Time in hr
+    t = 0.0    # Time [hr]
 
     # Initialization of cake length
-    Lck = 0.0    # Cake length in cm
+    Lck = 0.0    # Cake length [cm]
     percent_dried = Lck/Lpr0*100.0        # Percent dried
 
     # Initial chamber pressure
-    Pch = Pchamber['setpt'][0]        # Torr
+    Pch = Pchamber['setpt'][0]        # [Torr]
     Pchamber = Pchamber.copy()
     Pchamber['setpt'] = np.insert(Pchamber['setpt'],0,Pchamber['setpt'][0])        # Include initial chamber pressure in set point array
     # Chamber pressure control time
@@ -48,7 +48,7 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
         Pchamber['t_setpt'] = np.append(Pchamber['t_setpt'],Pchamber['t_setpt'][-1]+dt_j/constant.hr_To_min) 
        
     # Initial product and shelf temperatures
-    T0=product['T_pr_crit']   # degC
+    T0=product['T_pr_crit']   # [degC]
 
     ######################################################
 
@@ -56,29 +56,29 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
 
     while(Lck<=Lpr0): # Dry the entire frozen product
 
-        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance in cm^2-hr-Torr/g
+        Rp = functions.Rp_FUN(Lck,product['R0'],product['A1'],product['A2'])  # Product resistance [cm^2-hr-Torr/g]
     
         # Quantities solved for: x = [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv]
         def fun(x): 
             return (x[0]-x[4])    # Objective function to be minimized to maximize sublimation rate
         x0 = [Pch,0.0,T0,T0,Pch,T0,3.0e-4]    # Initial values
         # Constraints
-        cons = ({'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[0]},  # sublimation front pressure in Torr
-            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[1]},    # sublimation rate in kg/hr
+        cons = ({'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[0]},  # sublimation front pressure [Torr]
+            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[1]},    # sublimation rate [kg/hr]
             {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[2]},    # vial heat transfer balance
-            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[3]},    # shelf temperature in degC
-            {'type':'eq','fun':lambda x: x[6]-functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],x[0])},    # vial heat transfer coefficient in cal/s/K/cm^2
-            {'type':'eq','fun':lambda x: x[0]-Pch},    # chamber pressure fixed in Torr
+            {'type':'eq','fun':lambda x: functions.Eq_Constraints(x[0],x[1],x[2],x[3],x[4],x[5],x[6],Lpr0,Lck,vial['Av'],vial['Ap'],Rp)[3]},    # shelf temperature [degC]
+            {'type':'eq','fun':lambda x: x[6]-functions.Kv_FUN(ht['KC'],ht['KP'],ht['KD'],x[0])},    # vial heat transfer coefficient [cal/s/K/cm^2]
+            {'type':'eq','fun':lambda x: x[0]-Pch},    # chamber pressure fixed [Torr]
             {'type':'ineq','fun':lambda x: functions.Ineq_Constraints(x[0],x[1],product['T_pr_crit'],x[2],eq_cap['a'],eq_cap['b'],nVial)[0]},  # equipment capability inequlity
             {'type':'ineq','fun':lambda x: functions.Ineq_Constraints(x[0],x[1],product['T_pr_crit'],x[2],eq_cap['a'],eq_cap['b'],nVial)[1]})  # maximum product temperature inequality
         # Bounds for the unknowns
         bnds = ((None,None),(None,None),(None,None),(Tshelf['min'],Tshelf['max']),(None,None),(None,None),(None,None))
         # Minimize the objective function i.e. maximize the sublimation rate
         res = sp.minimize(fun,x0,bounds = bnds, constraints = cons)
-        [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv] = res['x']    # Results in Torr, kg/hr, degC, degC, Torr, degC, cal/s/K/cm^2
+        [Pch,dmdt,Tbot,Tsh,Psub,Tsub,Kv] = res['x']    # Results [Torr], [kg/hr], [degC], [degC], [Torr], [degC], [cal/s/K/cm^2]
 
         # Sublimated ice length
-        dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # cm
+        dL = (dmdt*constant.kg_To_g)*dt/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute) # [cm]
 
         # Update record as functions of the cycle time
         if (iStep==0):
@@ -87,14 +87,14 @@ def dry(vial,product,ht,Pchamber,Tshelf,dt,eq_cap,nVial):
             output_saved = np.append(output_saved, [[t, float(Tsub), float(Tbot), Tsh, Pch*constant.Torr_to_mTorr, dmdt/(vial['Ap']*constant.cm_To_m**2), percent_dried]],axis=0)
         
         # Advance counters
-        Lck_prev = Lck # Previous cake length in cm
-        Lck = Lck + dL # Cake length in cm
+        Lck_prev = Lck # Previous cake length [cm]
+        Lck = Lck + dL # Cake length [cm]
         if (Lck_prev < Lpr0) and (Lck > Lpr0):
-            Lck = Lpr0    # Final cake length in cm
-            dL = Lck - Lck_prev   # Cake length dried in cm
-            t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # hr
+            Lck = Lpr0    # Final cake length [cm]
+            dL = Lck - Lck_prev   # Cake length dried [cm]
+            t = iStep*dt + dL/((dmdt*constant.kg_To_g)/(1-product['cSolid']*constant.rho_solution/constant.rho_solute)/(vial['Ap']*constant.rho_ice)*(1-product['cSolid']*(constant.rho_solution-constant.rho_ice)/constant.rho_solute)) # [hr]
         else:
-            t = (iStep+1) * dt # Time in hr
+            t = (iStep+1) * dt # Time [hr]
 
         percent_dried = Lck/Lpr0*100   # Percent dried
 

--- a/tests/test_calc_knownRp.py
+++ b/tests/test_calc_knownRp.py
@@ -130,11 +130,11 @@ class TestCalcKnownRp:
         vial, product, ht, Pchamber, Tshelf, dt = knownRp_standard_setup
         output = calc_knownRp.dry(*knownRp_standard_setup)
         # Calculate initial water mass
-        Vfill = vial["Vfill"]  # mL
+        Vfill = vial["Vfill"]  # [mL]
         cSolid = product["cSolid"]
         water_mass_initial = (
             Vfill * constant.rho_solution * (1 - cSolid) / constant.kg_To_g
-        )  # kg
+        )  # [kg]
 
         # Integrate sublimation flux over time
         times = output[:, 0]  # [hr]

--- a/tests/test_design_space.py
+++ b/tests/test_design_space.py
@@ -153,8 +153,8 @@ class TestDesignSpaceBasic:
         # Equipment sublimation rate
         dmdt_eq = (
             eq_cap["a"] + eq_cap["b"] * Pchamber["setpt"][0]
-        )  # kg/hr for all vials
-        flux_eq_expected = dmdt_eq / nVial / (vial["Ap"] * 1e-4)  # kg/hr/m²
+        )  # [kg/hr] for all vials
+        flux_eq_expected = dmdt_eq / nVial / (vial["Ap"] * 1e-4)  # [kg/hr/m²]
 
         flux_eq_calculated = eq_cap_results[2][0]
 

--- a/tests/test_freezing.py
+++ b/tests/test_freezing.py
@@ -21,7 +21,7 @@ def check_max_time(output, Tshelf, dt):
 def freezing_params():
     vial = {"Av": 3.8, "Ap": 3.14, "Vfill": 2.0}
     product = {"Tpr0": 15.8, "Tf": -1.52, "Tn": -5.84, "cSolid": 0.05}
-    h_freezing = 38.0  # W/m²/K
+    h_freezing = 38.0  # [W/m²/K]
     Tshelf = {
         "init": 10.0,
         "setpt": np.array([-40.0]),
@@ -235,7 +235,7 @@ class TestFreezingReference:
     def freezing_params_ref(self):
         vial = {"Av": 3.8, "Ap": 3.14, "Vfill": 2.0}
         product = {"Tpr0": 15.8, "Tf": -1.54, "Tn": -5.84, "cSolid": 0.05}
-        h_freezing = 38.0  # W/m²/K
+        h_freezing = 38.0  # [W/m²/K]
         Tshelf = {
             "init": 10.0,
             "setpt": np.array([-40.0]),

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -44,8 +44,8 @@ class TestLpr0Function:
 
     def test_lpr0_standard_case(self):
         """Test initial fill height for standard 2 mL fill."""
-        Vfill = 2.0  # mL
-        Ap = 3.14  # cm^2
+        Vfill = 2.0  # [mL]
+        Ap = 3.14  # [cm^2]
         cSolid = 0.05
 
         Lpr0 = functions.Lpr0_FUN(Vfill, Ap, cSolid)
@@ -159,10 +159,10 @@ class TestSubRate:
 
     def test_sub_rate_positive_driving_force(self):
         """Sublimation rate should be positive when Psub > Pch."""
-        Ap = 3.14  # cm^2
-        Rp = 1.4  # cm^2-hr-Torr/g
-        T_sub = -20.0  # degC
-        Pch = 0.1  # Torr
+        Ap = 3.14  # [cm^2]
+        Rp = 1.4  # [cm^2-hr-Torr/g]
+        T_sub = -20.0  # [degC]
+        Pch = 0.1  # [Torr]
 
         dmdt = functions.sub_rate(Ap, Rp, T_sub, Pch)
 
@@ -218,10 +218,10 @@ class TestTBotFunction:
     def test_tbot_greater_than_tsub(self):
         """Bottom temperature should be greater than sublimation temperature."""
         T_sub = -20.0
-        Lpr0 = 0.7  # cm
-        Lck = 0.3  # cm
-        Pch = 0.1  # Torr
-        Rp = 1.4  # cm^2-hr-Torr/g
+        Lpr0 = 0.7  # [cm]
+        Lck = 0.3  # [cm]
+        Pch = 0.1  # [Torr]
+        Rp = 1.4  # [cm^2-hr-Torr/g]
 
         Tbot = functions.T_bot_FUN(T_sub, Lpr0, Lck, Pch, Rp)
 
@@ -320,7 +320,7 @@ class TestIneqConstraints:
 
         Missing coverage: lines 167-172 in functions.py
         """
-        # Test case 1: Normal case
+        # Test case 1: Normal case -- both constraints satisfied
         Pch = 0.080
         dmdt = 0.05
         Tpr_crit = -30.0

--- a/tests/test_opt_Pch.py
+++ b/tests/test_opt_Pch.py
@@ -233,7 +233,7 @@ class TestOptPchEdgeCases:
         vial, product, ht, Pchamber, Tshelf, dt, eq_cap, nVial = standard_opt_pch_inputs
 
         # Higher minimum pressure
-        Pchamber["min"] = 0.10  # Torr = 100 mTorr
+        Pchamber["min"] = 0.10  # [Torr] = 100 mTorr
         # Needs a lower shelf temperature to complete drying
         Tshelf["setpt"] = np.array([-20.0])
 
@@ -252,7 +252,7 @@ class TestOptPchEdgeCases:
         vial, product, ht, Pchamber, Tshelf, dt, eq_cap, nVial = standard_opt_pch_inputs
 
         # Higher minimum pressure
-        Pchamber["min"] = 0.10  # Torr = 100 mTorr
+        Pchamber["min"] = 0.10  # [Torr] = 100 mTorr
         # With higher shelf temperature, CANNOT complete drying and adhere to constraints
         Tshelf["setpt"] = [0]
 


### PR DESCRIPTION
## Summary
- Standardize unit notation from `# in <unit>` or `# <unit>` to `# [<unit>]` in comments and docstrings across all source and test files
- Pure documentation/style change with zero functional impact

## Test plan
- [x] All existing tests pass (comment-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)