### PR TITLE
Simplify CI workflows and update project configuration

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Determine test mode
       id: mode
       run: |
-        if [ "${{ github.event.pull_request.draft }}" ]; then
+        if [ "${{ github.event.pull_request.draft }}" == "true" ]; then
           echo "mode=fast" >> $GITHUB_OUTPUT
         else
           echo "mode=full" >> $GITHUB_OUTPUT
@@ -43,24 +43,20 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install .
-        pip install .[dev]
-        pip install -e . --no-build-isolation
+        pip install -e ".[dev]"
     
     - name: Run tests
-    # Currently this conditional branching doesn't actually do anything,
-    # since pyproject.toml adds these coverage arguments to the testing anyway
       run: |
         if [ "${{ steps.mode.outputs.mode }}" == "fast" ]; then
-          echo "⚡ Skipping notebook tests (marked with @pytest.mark.notebook) - these run separately"
-          pytest tests/ -n auto -v -m "not notebook" --cov=lyopronto --cov-report=term-missing
-        else
-          echo "⚡ Skipping notebook tests (marked with @pytest.mark.slow), not running coverage"
+          echo "Running fast tests (draft PR, no coverage)"
           pytest tests/ -n auto -v -m "not notebook"
+        else
+          echo "Running full tests with coverage (ready for review)"
+          pytest tests/ -n auto -v -m "not notebook" --cov=lyopronto --cov-report=term-missing --cov-report=xml
         fi
     
     - name: Upload coverage (if run)
-      if: steps.mode.outputs.coverage == 'true'
+      if: steps.mode.outputs.mode == 'full'
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -41,19 +41,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install .
-        pip install .[dev]
-        pip install -e . --no-build-isolation
+        pip install -e ".[dev]"
     
     - name: Run slow tests
       run: |
         if [ "${{ inputs.run_all }}" == "true" ]; then
-          echo "🔍 Running ALL tests (including slow optimization tests)"
-          echo "⏱️ This may take 30-40 minutes on CI"
+          echo "Running ALL tests (including slow optimization tests)"
+          echo "This may take 30-40 minutes on CI"
           pytest tests/ -n auto -v --cov=lyopronto --cov-report=xml --cov-report=term-missing
         else
-          echo "🐌 Running ONLY slow tests (marked with @pytest.mark.slow)"
-          echo "⏱️ This focuses on optimization tests that take minutes"
+          echo "Running ONLY slow tests (marked with @pytest.mark.slow)"
+          echo "This focuses on optimization tests that take minutes"
           pytest tests/ -n auto -v -m "slow" --cov=lyopronto --cov-report=xml --cov-report=term-missing
         fi
     
@@ -70,8 +68,8 @@ jobs:
       if: always()
       run: |
         if [ "${{ inputs.run_all }}" == "true" ]; then
-          echo "✅ Complete test suite finished"
+          echo "Complete test suite finished"
         else
-          echo "🐌 Slow tests completed"
+          echo "Slow tests completed"
         fi
-        echo "📊 Coverage uploaded to Codecov"
+        echo "Coverage uploaded to Codecov"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ name: Main Branch Tests
 
 on:
   push:
-    branches: [ main, dev-pyomo ]
+    branches: [ main ]
 
 jobs:
   test:
@@ -29,14 +29,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install .
-        pip install .[dev]
-        pip install -e . --no-build-isolation
+        pip install -e ".[dev]"
     
     - name: Run ALL tests with pytest and coverage (including slow tests)
       run: |
-        echo "🔍 Running complete test suite including slow tests"
-        echo "⏱️ This may take 30-40 minutes on CI (includes optimization tests)"
+        echo "Running complete test suite including slow tests"
+        echo "This may take 30-40 minutes on CI (includes optimization tests)"
         pytest tests/ -n auto -v --cov=lyopronto --cov-report=xml --cov-report=term-missing
     
     - name: Upload coverage to Codecov
@@ -51,5 +49,5 @@ jobs:
     - name: Coverage Summary
       if: always()
       run: |
-        echo "✅ Full coverage tests completed for main branch"
-        echo "📊 Coverage metrics updated in Codecov"
+        echo "Full coverage tests completed for main branch"
+        echo "Coverage metrics updated in Codecov"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,26 @@
 # ----------- Files excluded for this project
 #
-# Python precompiled files
-*.pyc
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+MANIFEST
+
 # Data files
 *.csv
+# But keep test reference data
+!test_data/*.csv
+
+# Coverage reports
+.coverage
+coverage.xml
+htmlcov/
 
 docs/build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ authors = [
 maintainers = [
     {name = "Isaac S. Wheeler"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.24.0",
+    "numpy>=2.0.0",
     "scipy>=1.10.0",
     "matplotlib>=3.7.0",
     "ruamel.yaml>=0.18.0",
@@ -29,7 +29,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -45,6 +44,7 @@ dev = [
     "pytest-mock>=3",
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.3.0",
+    "pytest-timeout>=2.1.0",
     "hypothesis>=6.82.0",
     "ruff>=0.12.0",
     "mypy>=1.4.0",
@@ -80,8 +80,6 @@ addopts = [
     "--strict-markers",
     "--tb=short",
     "--maxfail=5",
-    "--cov=lyopronto",
-    "--cov-report=term-missing",
 ]
 markers = [
     "slow: Tests that take a long time to run",


### PR DESCRIPTION
## Summary
- Fix pip install to use single `pip install -e ".[dev]"` instead of triple install in all CI workflows
- Fix inverted draft/full test logic in pr-tests.yml (draft should skip coverage for fast feedback)
- Remove `dev-pyomo` branch trigger from tests.yml
- Remove emoji from CI echo statements for portability
- Bump numpy to >=2.0.0, Python to >=3.9
- Remove `--cov` from default pytest addopts (let CI pass `--cov` explicitly)
- Add standard Python patterns to .gitignore

## Test plan
- [x] All existing tests pass
- [x] CI workflows correctly handle draft vs ready PR logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)